### PR TITLE
Topic/rocko fixes

### DIFF
--- a/recipes-kernel/linux/linux-indist.inc
+++ b/recipes-kernel/linux/linux-indist.inc
@@ -4,7 +4,8 @@ SRC_URI_append_axxiax86-64 = " \
     file://${RDK_KLM_ARCHIVE} \
     file://rdk-modules.scc "
 
-RDK_KLM_VERSION ?= "unknown-release-info"
+META_INTEL_AXXIA_RDK_LAYER_PATH:="${THISDIR}"
+export META_INTEL_AXXIA_RDK_LAYER_PATH
 
 do_patch_rdk_modules () {
     cd ${STAGING_KERNEL_DIR}
@@ -12,6 +13,9 @@ do_patch_rdk_modules () {
         git stash
         CHANGES=yes
     fi
+
+    RDK_KLM_VERSION=$(git -C ${META_INTEL_AXXIA_RDK_LAYER_PATH} describe --dirty)
+    echo ${RDK_KLM_VERSION}
 
     for KLMC in cpk cpk-ae hqm ies qat
     do

--- a/recipes-kernel/linux/linux-indist.inc
+++ b/recipes-kernel/linux/linux-indist.inc
@@ -27,7 +27,7 @@ do_patch_rdk_modules () {
         fi
  
         TIPC="$(echo ${KLMC} | tr '[:lower:]' '[:upper:]') ${RDK_KLM_VERSION}"
-        git commit -m "${TIPC}" -m "NOT FOR RELEASE"
+        git commit --author="Intel <axxia@intel.com>" -m "${TIPC}" -m "NOT FOR RELEASE"
     done
 
     if [ "yes" = "${CHANGES}" ]; then


### PR DESCRIPTION
Two nice additions to meta-intel-axxia-rdk :

1. Don't use the build user as author for the generated commits.
2. Let the delivery define version instead of the delivery user.